### PR TITLE
Fix pagination

### DIFF
--- a/talks/templates/talk/list.html
+++ b/talks/templates/talk/list.html
@@ -45,6 +45,6 @@
             </div>
         </div>
 
-        {% bootstrap_pagination page_obj %}
+        {% bootstrap_pagination page_obj extra=pagination_extra %}
     </div>
 {% endblock %}

--- a/talks/views.py
+++ b/talks/views.py
@@ -20,10 +20,10 @@ class IndexView(generic.ListView):
 
     def get_queryset(self):
         """Return the last five published questions."""
-        query = self.request.GET.get('q')
+        self.query = self.request.GET.get('q')
         queryset = Talk.objects.order_by('pk')
-        if query:
-            queryset = queryset.filter(title__icontains=query)
+        if self.query:
+            queryset = queryset.filter(title__icontains=self.query)
         return queryset
 
     def get_context_data(self, **kwargs):
@@ -31,6 +31,7 @@ class IndexView(generic.ListView):
         context = super(IndexView, self).get_context_data(**kwargs)
         # Add in the publisher
         context['search_query'] = self.request.GET.get('q') or ''
+        context['pagination_extra'] = f'q={self.query}' if self.query else None
         return context
 
 

--- a/talks/views.py
+++ b/talks/views.py
@@ -21,11 +21,10 @@ class IndexView(generic.ListView):
     def get_queryset(self):
         """Return the last five published questions."""
         query = self.request.GET.get('q')
-        if query is None:
-            return Talk.objects.all()
-        return Talk.objects.filter(
-            Q(title__icontains=query)
-        ).all()
+        queryset = Talk.objects.order_by('pk')
+        if query:
+            queryset = queryset.filter(title__icontains=query)
+        return queryset
 
     def get_context_data(self, **kwargs):
         # Call the base implementation first to get a context


### PR DESCRIPTION
Fixes https://github.com/esquire900/tmi-archive/issues/6

I've also added a default ordering to the queryset because of this warning:

> /usr/local/lib/python3.8/site-packages/django/views/generic/list.py:86: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'talks.models.Talk'> QuerySet.
